### PR TITLE
force redirect to brooklab.org/news

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,6 +2,13 @@
 {% include head.html %}
 <body>
 
+please try visiting [brooklab.org](https://brooklab.org)
+
+<script type="text/javascript">
+  // Simulate an HTTP redirect:
+  window.location.replace("https://brooklab.org/news");
+</script>
+
 <div class="wrapper">
 <!--{% include header.html %}-->
  {{ content }}


### PR DESCRIPTION
adds a basic javascript redirect to direct any user from carabrook.github.io/blog ~> brooklab.org/news